### PR TITLE
Remove ancestral indents

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -32,3 +32,9 @@
 	pointer-events: none;
 	display: none;
 }
+
+.folder-focus-mode.folder-focus-mode-simplified .tree-item-children:has(.folderfocus-up-element) {
+	margin-inline-start: 0px;
+	padding-inline-start: 0px;
+	border-inline-start: none;
+}


### PR DESCRIPTION
Since the purpose of this plugin is to focus on the folder selected, I believe it's redundant to leave all the indentations of hidden ancestors in the file manager view.

![Obsidian_QMgbmRcRCu](https://github.com/user-attachments/assets/8a364a15-a9ba-4774-8ac9-35d3869b85fd)

This CSS change:
- removes ancestral indents (margin, padding, and border
- provides extra space for the titles of the selected folder